### PR TITLE
Implement ELF header parsing

### DIFF
--- a/UnionPatcher.Gui/MainForm.cs
+++ b/UnionPatcher.Gui/MainForm.cs
@@ -71,20 +71,20 @@ namespace LBPUnion.UnionPatcher.Gui {
 
                 ElfFile eboot = new(this.filePicker.FilePath);
 
-				if(eboot.IsValid == false) {
-					this.CreateOkDialog("Eboot Error", $"{eboot.Name} is not a valid ELF file (magic number mismatch)").ShowModal();
-					return;
-				}
+                if(eboot.IsValid == false) {
+                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} is not a valid ELF file (magic number mismatch)").ShowModal();
+                    return;
+                }
 
-				if(eboot.Is64Bit == null) {
-					this.CreateOkDialog("Eboot Error", $"{eboot.Name} does not target a valid system").ShowModal();
-					return;
-				}
+                if(eboot.Is64Bit == null) {
+                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} does not target a valid system").ShowModal();
+                    return;
+                }
 
-				if(string.IsNullOrWhiteSpace(eboot.Architecture)) {
-					this.CreateOkDialog("Eboot Error", $"{eboot.Name} does not target a valid architecture (PowerPC or ARM)").ShowModal();
-					return;
-				}
+                if(string.IsNullOrWhiteSpace(eboot.Architecture)) {
+                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} does not target a valid architecture (PowerPC or ARM)").ShowModal();
+                    return;
+                }
 
                 try {
                     Patcher.PatchFile(this.filePicker.FilePath, this.serverUrl.Text, this.outputFileName.FilePath);

--- a/UnionPatcher.Gui/MainForm.cs
+++ b/UnionPatcher.Gui/MainForm.cs
@@ -72,7 +72,7 @@ namespace LBPUnion.UnionPatcher.Gui {
                 ElfFile eboot = new(this.filePicker.FilePath);
 
                 if(eboot.IsValid == false) {
-                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} is not a valid ELF file (magic number mismatch)").ShowModal();
+                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} is not a valid ELF file (magic number mismatch)\nThe EBOOT must be decrypted before using this tool").ShowModal();
                     return;
                 }
 

--- a/UnionPatcher.Gui/MainForm.cs
+++ b/UnionPatcher.Gui/MainForm.cs
@@ -72,17 +72,17 @@ namespace LBPUnion.UnionPatcher.Gui {
                 ElfFile eboot = new(this.filePicker.FilePath);
 
                 if(eboot.IsValid == false) {
-                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} is not a valid ELF file (magic number mismatch)\nThe EBOOT must be decrypted before using this tool").ShowModal();
+                    this.CreateOkDialog("EBOOT Error", $"{eboot.Name} is not a valid ELF file (magic number mismatch)\nThe EBOOT must be decrypted before using this tool").ShowModal();
                     return;
                 }
 
                 if(eboot.Is64Bit == null) {
-                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} does not target a valid system").ShowModal();
+                    this.CreateOkDialog("EBOOT Error", $"{eboot.Name} does not target a valid system").ShowModal();
                     return;
                 }
 
                 if(string.IsNullOrWhiteSpace(eboot.Architecture)) {
-                    this.CreateOkDialog("Eboot Error", $"{eboot.Name} does not target a valid architecture (PowerPC or ARM)").ShowModal();
+                    this.CreateOkDialog("EBOOT Error", $"{eboot.Name} does not target a valid architecture (PowerPC or ARM)").ShowModal();
                     return;
                 }
 

--- a/UnionPatcher/ElfFile.cs
+++ b/UnionPatcher/ElfFile.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Buffers.Binary;
+
+/*
+Linux ELF header refspec: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
+Wikipedia entry on ELF: https://en.wikipedia.org/wiki/Executable_and_Linkable_Format
+*/
+
+namespace LBPUnion.UnionPatcher {
+	public class ElfFile {
+		private enum WordSize : byte {
+			ThirtyTwoBits = 0x01,
+			SixtyFourBits = 0x02
+		}
+
+		private enum Endianness : byte {
+			Little = 0x01,
+			Big = 0x02
+		}
+
+		private enum InstructionSetArchitecture : UInt16 {
+			PowerPC = 0x15, //64-bit PowerPC (PS3)
+			ARM = 0x28 //32-bit ARM (Vita)
+		}
+
+		public string Name { get; } = "Binary Blob";
+
+		public bool IsValid { get; }
+		public bool? Is64Bit { get; } = null;
+		public bool? IsBigEndian { get; } = null;
+		public string Architecture { get; } = null;
+
+		public byte[] Contents { get; } = null;
+
+		public ElfFile(byte[] fileContents) {
+			IsValid = fileContents[0x00..0x04].SequenceEqual(new byte[] {0x7F, (byte)'E', (byte)'L', (byte)'F'});
+			if(IsValid == false) return;
+
+			byte identClassValue = fileContents[0x04];
+			byte identDataValue = fileContents[0x05];
+
+			if(identClassValue == (byte)WordSize.ThirtyTwoBits || identClassValue == (byte)WordSize.SixtyFourBits)
+				Is64Bit = identClassValue == (byte)WordSize.SixtyFourBits;
+
+			if(identDataValue == (byte)Endianness.Little || identDataValue == (byte)Endianness.Big)
+				IsBigEndian = identDataValue == (byte)Endianness.Big;
+
+			Architecture = GetFileArchitecture(fileContents, IsBigEndian == true);
+
+			Contents = fileContents;
+		}
+
+		public ElfFile(FileInfo file) : this(File.ReadAllBytes(file.FullName)) {
+			Name = file.Name;
+		}
+
+		public ElfFile(string fileName) : this(new FileInfo(fileName)) {}
+
+		private string GetFileArchitecture(byte[] elfHeader, bool isBigEndian) {
+			byte[] architectureBytes = elfHeader[0x12..0x14];
+			UInt16 fileArch = (isBigEndian) ?
+				BinaryPrimitives.ReadUInt16BigEndian(architectureBytes) :
+				BinaryPrimitives.ReadUInt16LittleEndian(architectureBytes);
+
+			foreach(InstructionSetArchitecture arch in Enum.GetValues(typeof(InstructionSetArchitecture))) {
+				if(fileArch == (UInt16)arch)
+					return arch.ToString();
+			}
+			return null;
+		}
+	}
+}

--- a/UnionPatcher/ElfFile.cs
+++ b/UnionPatcher/ElfFile.cs
@@ -35,8 +35,8 @@ namespace LBPUnion.UnionPatcher {
         public byte[] Contents { get; } = null;
 
         public ElfFile(byte[] fileContents) {
-			if(fileContents.Length < 52)
-				return;
+            if(fileContents.Length < 52)
+                return;
 
             IsValid = fileContents[0x00..0x04].SequenceEqual(new byte[] {0x7F, (byte)'E', (byte)'L', (byte)'F'});
             if(!IsValid) return;

--- a/UnionPatcher/ElfFile.cs
+++ b/UnionPatcher/ElfFile.cs
@@ -9,66 +9,66 @@ Wikipedia entry on ELF: https://en.wikipedia.org/wiki/Executable_and_Linkable_Fo
 */
 
 namespace LBPUnion.UnionPatcher {
-	public class ElfFile {
-		private enum WordSize : byte {
-			ThirtyTwoBits = 0x01,
-			SixtyFourBits = 0x02
-		}
+    public class ElfFile {
+        private enum WordSize : byte {
+            ThirtyTwoBits = 0x01,
+            SixtyFourBits = 0x02
+        }
 
-		private enum Endianness : byte {
-			Little = 0x01,
-			Big = 0x02
-		}
+        private enum Endianness : byte {
+            Little = 0x01,
+            Big = 0x02
+        }
 
-		private enum InstructionSetArchitecture : UInt16 {
-			PowerPC = 0x15, //64-bit PowerPC (PS3)
-			ARM = 0x28 //32-bit ARM (Vita)
-		}
+        private enum InstructionSetArchitecture : UInt16 {
+            PowerPC = 0x15, //64-bit PowerPC (PS3)
+            ARM = 0x28 //32-bit ARM (Vita)
+        }
 
-		public string Name { get; } = "Binary Blob";
+        public string Name { get; } = "Binary Blob";
 
-		public bool IsValid { get; }
-		public bool? Is64Bit { get; } = null;
-		public bool? IsBigEndian { get; } = null;
-		public string Architecture { get; } = null;
+        public bool IsValid { get; }
+        public bool? Is64Bit { get; } = null;
+        public bool? IsBigEndian { get; } = null;
+        public string Architecture { get; } = null;
 
-		public byte[] Contents { get; } = null;
+        public byte[] Contents { get; } = null;
 
-		public ElfFile(byte[] fileContents) {
-			IsValid = fileContents[0x00..0x04].SequenceEqual(new byte[] {0x7F, (byte)'E', (byte)'L', (byte)'F'});
-			if(IsValid == false) return;
+        public ElfFile(byte[] fileContents) {
+            IsValid = fileContents[0x00..0x04].SequenceEqual(new byte[] {0x7F, (byte)'E', (byte)'L', (byte)'F'});
+            if(IsValid == false) return;
 
-			byte identClassValue = fileContents[0x04];
-			byte identDataValue = fileContents[0x05];
+            byte identClassValue = fileContents[0x04];
+            byte identDataValue = fileContents[0x05];
 
-			if(identClassValue == (byte)WordSize.ThirtyTwoBits || identClassValue == (byte)WordSize.SixtyFourBits)
-				Is64Bit = identClassValue == (byte)WordSize.SixtyFourBits;
+            if(identClassValue == (byte)WordSize.ThirtyTwoBits || identClassValue == (byte)WordSize.SixtyFourBits)
+                Is64Bit = identClassValue == (byte)WordSize.SixtyFourBits;
 
-			if(identDataValue == (byte)Endianness.Little || identDataValue == (byte)Endianness.Big)
-				IsBigEndian = identDataValue == (byte)Endianness.Big;
+            if(identDataValue == (byte)Endianness.Little || identDataValue == (byte)Endianness.Big)
+                IsBigEndian = identDataValue == (byte)Endianness.Big;
 
-			Architecture = GetFileArchitecture(fileContents, IsBigEndian == true);
+            Architecture = GetFileArchitecture(fileContents, IsBigEndian == true);
 
-			Contents = fileContents;
-		}
+            Contents = fileContents;
+        }
 
-		public ElfFile(FileInfo file) : this(File.ReadAllBytes(file.FullName)) {
-			Name = file.Name;
-		}
+        public ElfFile(FileInfo file) : this(File.ReadAllBytes(file.FullName)) {
+            Name = file.Name;
+        }
 
-		public ElfFile(string fileName) : this(new FileInfo(fileName)) {}
+        public ElfFile(string fileName) : this(new FileInfo(fileName)) {}
 
-		private string GetFileArchitecture(byte[] elfHeader, bool isBigEndian) {
-			byte[] architectureBytes = elfHeader[0x12..0x14];
-			UInt16 fileArch = (isBigEndian) ?
-				BinaryPrimitives.ReadUInt16BigEndian(architectureBytes) :
-				BinaryPrimitives.ReadUInt16LittleEndian(architectureBytes);
+        private string GetFileArchitecture(byte[] elfHeader, bool isBigEndian) {
+            byte[] architectureBytes = elfHeader[0x12..0x14];
+            UInt16 fileArch = (isBigEndian) ?
+                BinaryPrimitives.ReadUInt16BigEndian(architectureBytes) :
+                BinaryPrimitives.ReadUInt16LittleEndian(architectureBytes);
 
-			foreach(InstructionSetArchitecture arch in Enum.GetValues(typeof(InstructionSetArchitecture))) {
-				if(fileArch == (UInt16)arch)
-					return arch.ToString();
-			}
-			return null;
-		}
-	}
+            foreach(InstructionSetArchitecture arch in Enum.GetValues(typeof(InstructionSetArchitecture))) {
+                if(fileArch == (UInt16)arch)
+                    return arch.ToString();
+            }
+            return null;
+        }
+    }
 }

--- a/UnionPatcher/ElfFile.cs
+++ b/UnionPatcher/ElfFile.cs
@@ -35,8 +35,13 @@ namespace LBPUnion.UnionPatcher {
         public byte[] Contents { get; } = null;
 
         public ElfFile(byte[] fileContents) {
+			if(fileContents.length < 52) {
+				IsValid = false;
+				return;
+			}
+
             IsValid = fileContents[0x00..0x04].SequenceEqual(new byte[] {0x7F, (byte)'E', (byte)'L', (byte)'F'});
-            if(IsValid == false) return;
+            if(!IsValid) return;
 
             byte identClassValue = fileContents[0x04];
             byte identDataValue = fileContents[0x05];

--- a/UnionPatcher/ElfFile.cs
+++ b/UnionPatcher/ElfFile.cs
@@ -27,7 +27,7 @@ namespace LBPUnion.UnionPatcher {
 
         public string Name { get; } = "Binary Blob";
 
-        public bool IsValid { get; }
+        public bool IsValid { get; } = false;
         public bool? Is64Bit { get; } = null;
         public bool? IsBigEndian { get; } = null;
         public string Architecture { get; } = null;
@@ -35,10 +35,8 @@ namespace LBPUnion.UnionPatcher {
         public byte[] Contents { get; } = null;
 
         public ElfFile(byte[] fileContents) {
-			if(fileContents.length < 52) {
-				IsValid = false;
+			if(fileContents.Length < 52)
 				return;
-			}
 
             IsValid = fileContents[0x00..0x04].SequenceEqual(new byte[] {0x7F, (byte)'E', (byte)'L', (byte)'F'});
             if(!IsValid) return;

--- a/UnionPatcher/Program.cs
+++ b/UnionPatcher/Program.cs
@@ -25,21 +25,21 @@ namespace LBPUnion.UnionPatcher {
             ElfFile eboot = new(new FileInfo(args[0]));
 
             if(eboot.IsValid == false) {
-				Console.WriteLine($"{eboot.Name} is not a valid ELF file (magic number mismatch)");
-				return;
-			}
+                Console.WriteLine($"{eboot.Name} is not a valid ELF file (magic number mismatch)");
+                return;
+            }
 
-			if(eboot.Is64Bit == null) {
-				Console.WriteLine($"{eboot.Name} does not target a valid system");
-				return;
-			}
+            if(eboot.Is64Bit == null) {
+                Console.WriteLine($"{eboot.Name} does not target a valid system");
+                return;
+            }
 
-			if(string.IsNullOrWhiteSpace(eboot.Architecture)) {
-				Console.WriteLine($"{eboot.Name} does not target a valid architecture (PowerPC or ARM)");
-				return;
-			}
+            if(string.IsNullOrWhiteSpace(eboot.Architecture)) {
+                Console.WriteLine($"{eboot.Name} does not target a valid architecture (PowerPC or ARM)");
+                return;
+            }
 
-			Console.WriteLine($"{eboot.Name} targets {eboot.Architecture}");
+            Console.WriteLine($"{eboot.Name} targets {eboot.Architecture}");
 
             Patcher.PatchFile(args[0], args[1], args[2]);
             Console.WriteLine($"Successfully patched Server URL to {args[1]}.");

--- a/UnionPatcher/Program.cs
+++ b/UnionPatcher/Program.cs
@@ -24,8 +24,9 @@ namespace LBPUnion.UnionPatcher {
 
             ElfFile eboot = new(new FileInfo(args[0]));
 
-            if(eboot.IsValid == false) {
+            if(!eboot.IsValid) {
                 Console.WriteLine($"{eboot.Name} is not a valid ELF file (magic number mismatch)");
+                Console.WriteLine("The EBOOT must be decrypted before using this tool");
                 return;
             }
 

--- a/UnionPatcher/Program.cs
+++ b/UnionPatcher/Program.cs
@@ -15,13 +15,32 @@ namespace LBPUnion.UnionPatcher {
                 return fileName = Path.GetFileName(Process.GetCurrentProcess().MainModule?.FileName);
             }
         }
-        
+
         public static void Main(string[] args) {
             if(args.Length < 3) {
                 PrintHelp();
                 return;
             }
-            
+
+            ElfFile eboot = new(new FileInfo(args[0]));
+
+            if(eboot.IsValid == false) {
+				Console.WriteLine($"{eboot.Name} is not a valid ELF file (magic number mismatch)");
+				return;
+			}
+
+			if(eboot.Is64Bit == null) {
+				Console.WriteLine($"{eboot.Name} does not target a valid system");
+				return;
+			}
+
+			if(string.IsNullOrWhiteSpace(eboot.Architecture)) {
+				Console.WriteLine($"{eboot.Name} does not target a valid architecture (PowerPC or ARM)");
+				return;
+			}
+
+			Console.WriteLine($"{eboot.Name} targets {eboot.Architecture}");
+
             Patcher.PatchFile(args[0], args[1], args[2]);
             Console.WriteLine($"Successfully patched Server URL to {args[1]}.");
         }


### PR DESCRIPTION
Merging this should close #7 

This will ensure that basic ELF file checks can be verified - it should be easy enough to extend into something more complex (Require the ELF file to be 64-bit/PowerPC for PS3, etc)