### PR TITLE
Fix application closing when choosing mode on Windows

### DIFF
--- a/UnionPatcher.Gui/Forms/ModeSelectionForm.cs
+++ b/UnionPatcher.Gui/Forms/ModeSelectionForm.cs
@@ -27,14 +27,24 @@ public class ModeSelectionForm : Form {
     }
     
     private void openRemotePatcher(object sender, EventArgs e) {
-        new RemotePatchForm().Show();
-        this.Close();
+        RemotePatchForm rpForm = new RemotePatchForm();
+        rpForm.Show();
+        rpForm.Closed += OnSubFormClose;
+
+        this.Visible = false;
     }
     private void openLocalPatcher(object sender, EventArgs e) {
         throw new NotImplementedException();
     }
     private void openFilePatcher(object sender, EventArgs e) {
-        new FilePatchForm().Show();
+        FilePatchForm fpForm = new FilePatchForm();
+        fpForm.Show();
+        fpForm.Closed += OnSubFormClose;
+
+        this.Visible = false;
+    }
+    private void OnSubFormClose(object sender, EventArgs e)
+    {
         this.Close();
     }
 


### PR DESCRIPTION
When a new sub form is opened, the main form's ``Close()`` method is called, which halts the entire application on Windows. Instead, we create an instance of the sub form, and bind its ``Closed`` event to an event handler that will halt the entire application.

We can then hide the main form, rather than closing it completely, which resolves the issue and allows the app to run as intended.