### PR TITLE
Added regex matching to find index of LBP server URLs

### DIFF
--- a/UnionPatcher/Patcher.cs
+++ b/UnionPatcher/Patcher.cs
@@ -54,8 +54,8 @@ public static class Patcher {
         foreach(Match urlMatch in urls) {
             string url = urlMatch.Value;
 
-            if(serverUrl.Length > url.Length) {
-                throw new ArgumentOutOfRangeException(nameof(serverUrl), $"Server URL ({serverUrl.Length} characters long) is above maximum length {url.Length}");
+            if(serverUrl.Length > url.Length - 1) {
+                throw new ArgumentOutOfRangeException(nameof(serverUrl), $"Server URL ({serverUrl.Length} characters long) is above maximum length {url.Length - 1}");
             }
             int offset = urlMatch.Index;
 

--- a/UnionPatcher/Patcher.cs
+++ b/UnionPatcher/Patcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace LBPUnion.UnionPatcher; 
 
@@ -72,13 +73,18 @@ public static class Patcher {
         byte[] serverUrlAsBytes = Encoding.ASCII.GetBytes(serverUrl);
 
         bool wroteUrl = false;
-        foreach(string url in toBePatched) {
-            if(serverUrl.Length > url.Length) {
+
+        // Find a string including http or https and LITTLEBIGPLANETPS3_XML or LITTLEBIGPLANETPSP_XML
+        MatchCollection urls = Regex.Matches(dataAsString, "https?.*?LITTLEBIGPLANETPS(3|P)_XML");
+        foreach(Match urlMatch in urls) {
+            string url = urlMatch.Value;
+
+            // Hard coded 79 max length
+            // TODO: Get length of index to next data in EBOOT to calcuate true maximum length
+            if(serverUrl.Length > 79) {
                 throw new ArgumentOutOfRangeException(nameof(serverUrl), $"Server URL ({serverUrl.Length} characters long) is above maximum length {url.Length}");
             }
-                
-            int offset = dataAsString.IndexOf(url, StringComparison.Ordinal);
-            if(offset < 1) continue;
+            int offset = urlMatch.Index;
 
             writer.BaseStream.Position = offset;
             for(int i = 0; i < url.Length; i++) {

--- a/UnionPatcher/Patcher.cs
+++ b/UnionPatcher/Patcher.cs
@@ -50,7 +50,7 @@ public static class Patcher {
         // Find a string including http or https and LITTLEBIGPLANETPS3_XML or LITTLEBIGPLANETPSP_XML, 
         // then match any additional NULL characters to dynamically gague the maximum length on a per-title basis 
         // without a hardcoded array of known server URLs
-        MatchCollection urls = Regex.Matches(dataAsString, "(https?.*?LITTLEBIGPLANETPS(3|P)_XML)(\x00*)");
+        MatchCollection urls = Regex.Matches(dataAsString, "http?[^\x00]*?LITTLEBIGPLANETPS(3|P)_XML\x00");
         foreach(Match urlMatch in urls) {
             string url = urlMatch.Value;
 

--- a/UnionPatcher/Patcher.cs
+++ b/UnionPatcher/Patcher.cs
@@ -6,33 +6,6 @@ using System.Text.RegularExpressions;
 namespace LBPUnion.UnionPatcher; 
 
 public static class Patcher {
-    private static readonly string[] toBePatched = {
-        // Normal LittleBigPlanet gameserver URLs
-        "https://littlebigplanetps3.online.scee.com:10061/LITTLEBIGPLANETPS3_XML",
-        "http://littlebigplanetps3.online.scee.com:10060/LITTLEBIGPLANETPS3_XML",
-        // LittleBigPlanet 3 Presence URLs
-        "http://live.littlebigplanetps3.online.scee.com:10060/LITTLEBIGPLANETPS3_XML",
-        "http://presence.littlebigplanetps3.online.scee.com:10060/LITTLEBIGPLANETPS3_XML",
-        #region Spinoff URLs
-        // LittleBigPlanet PSP URLs
-        "http://lbppsp.online.scee.com:10060/LITTLEBIGPLANETPSP_XML",
-        "https://lbppsp.online.scee.com:10061/LITTLEBIGPLANETPSP_XML",
-        // LittleBigPlanet Vita URLs
-        "http://lbpvita.online.scee.com:10060/LITTLEBIGPLANETPS3_XML",
-        "https://lbpvita.online.scee.com:10061/LITTLEBIGPLANETPS3_XML",
-        #endregion
-        #region Beta URLS
-        // LittleBigPlanet 2 Beta URLs
-        "http://lbp2ps3-beta.online.scee.com:10060/LITTLEBIGPLANETPS3_XML",
-        "https://lbp2ps3-beta.online.scee.com:10061/LITTLEBIGPLANETPS3_XML",
-        // LittleBigPlanet (3?) Beta URLs
-        "http://littlebigplanetps3-beta.online.scee.com:10060/LITTLEBIGPLANETPS3_XML",
-        "https://littlebigplanetps3-beta.online.scee.com:10061/LITTLEBIGPLANETPS3_XML",
-        // LittleBigPlanet Vita Beta URLs
-        "http://lbpvita-beta.online.scee.com:10060/LITTLEBIGPLANETPS3_XML",
-        "https://lbpvita-beta.online.scee.com:10061/LITTLEBIGPLANETPS3_XML",
-        #endregion
-    };
 
     public static void PatchFile(string fileName, Uri serverUrl, string outputFileName) {
         PatchFile(fileName, serverUrl.ToString(), outputFileName);
@@ -74,14 +47,14 @@ public static class Patcher {
 
         bool wroteUrl = false;
 
-        // Find a string including http or https and LITTLEBIGPLANETPS3_XML or LITTLEBIGPLANETPSP_XML
-        MatchCollection urls = Regex.Matches(dataAsString, "https?.*?LITTLEBIGPLANETPS(3|P)_XML");
+        // Find a string including http or https and LITTLEBIGPLANETPS3_XML or LITTLEBIGPLANETPSP_XML, 
+        // then match any additional NULL characters to dynamically gague the maximum length on a per-title basis 
+        // without a hardcoded array of known server URLs
+        MatchCollection urls = Regex.Matches(dataAsString, "(https?.*?LITTLEBIGPLANETPS(3|P)_XML)(\x00*)");
         foreach(Match urlMatch in urls) {
             string url = urlMatch.Value;
 
-            // Hard coded 79 max length
-            // TODO: Get length of index to next data in EBOOT to calcuate true maximum length
-            if(serverUrl.Length > 79) {
+            if(serverUrl.Length > url.Length) {
                 throw new ArgumentOutOfRangeException(nameof(serverUrl), $"Server URL ({serverUrl.Length} characters long) is above maximum length {url.Length}");
             }
             int offset = urlMatch.Index;

--- a/UnionPatcher/Patcher.cs
+++ b/UnionPatcher/Patcher.cs
@@ -50,7 +50,7 @@ public static class Patcher {
         // Find a string including http or https and LITTLEBIGPLANETPS3_XML or LITTLEBIGPLANETPSP_XML, 
         // then match any additional NULL characters to dynamically gague the maximum length on a per-title basis 
         // without a hardcoded array of known server URLs
-        MatchCollection urls = Regex.Matches(dataAsString, "http?[^\x00]*?LITTLEBIGPLANETPS(3|P)_XML\x00");
+        MatchCollection urls = Regex.Matches(dataAsString, "http?[^\x00]*?LITTLEBIGPLANETPS(3|P)_XML\x00*");
         foreach(Match urlMatch in urls) {
             string url = urlMatch.Value;
 


### PR DESCRIPTION
#### I can't guarantee this will work flawlessly but in limited testing it seems to work fine. 
Uses regex to match LBP server URLs as well as dynamically gathers the maximum length for a server URL on a per-title basis. Eliminates the need for a list of known servers.

While I am currently unable to test PSP and PS Vita EBOOTs, I am testing the 3 mainline titles on real PS3 hardware as well as a successful test on RPCS3.