### PR TITLE
Make the file picker only show valid files

### DIFF
--- a/UnionPatcher.Gui/Forms/FilePatchForm.cs
+++ b/UnionPatcher.Gui/Forms/FilePatchForm.cs
@@ -49,7 +49,7 @@ public class FilePatchForm : Form {
             Rows = {
                 new TableRow(
                     new TableCell(new Label { Text = "EBOOT.elf: ", VerticalAlignment = VerticalAlignment.Center }),
-                    new TableCell(this.filePicker = new FilePicker { TabIndex = 0 })
+                    new TableCell(this.filePicker = new FilePicker { TabIndex = 0 , FileAction = FileAction.OpenFile, Filters = { new FileFilter("ELF files", ".elf", ".ELF"), new FileFilter("All Files", ".*") }})
                 ),
                 new TableRow(
                     new TableCell(new Label { Text = "Server URL: ", VerticalAlignment = VerticalAlignment.Center }),
@@ -57,7 +57,7 @@ public class FilePatchForm : Form {
                 ),
                 new TableRow(
                     new TableCell(new Label { Text = "Output filename: ", VerticalAlignment = VerticalAlignment.Center }),
-                    new TableCell(this.outputFileName = new FilePicker { TabIndex = 2, FileAction = FileAction.SaveFile })
+                    new TableCell(this.outputFileName = new FilePicker { TabIndex = 2, FileAction = FileAction.SaveFile,  Filters = { new FileFilter("ELF files", ".elf", ".ELF"), new FileFilter("All Files", ".*") }})
                 ),
                 new TableRow(
                     new TableCell(this.CreateHelpButton(4)),

--- a/UnionPatcher.Gui/Forms/FilePatchForm.cs
+++ b/UnionPatcher.Gui/Forms/FilePatchForm.cs
@@ -49,7 +49,7 @@ public class FilePatchForm : Form {
             Rows = {
                 new TableRow(
                     new TableCell(new Label { Text = "EBOOT.elf: ", VerticalAlignment = VerticalAlignment.Center }),
-                    new TableCell(this.filePicker = new FilePicker { TabIndex = 0 , FileAction = FileAction.OpenFile, Filters = { new FileFilter("ELF files", ".elf", ".ELF"), new FileFilter("All Files", ".*") }})
+                    new TableCell(this.filePicker = new FilePicker { TabIndex = 0 , FileAction = FileAction.OpenFile, Filters = { new FileFilter("ELF files", "*.elf", "*.ELF"), new FileFilter("All Files", "*.*") }})
                 ),
                 new TableRow(
                     new TableCell(new Label { Text = "Server URL: ", VerticalAlignment = VerticalAlignment.Center }),
@@ -57,7 +57,7 @@ public class FilePatchForm : Form {
                 ),
                 new TableRow(
                     new TableCell(new Label { Text = "Output filename: ", VerticalAlignment = VerticalAlignment.Center }),
-                    new TableCell(this.outputFileName = new FilePicker { TabIndex = 2, FileAction = FileAction.SaveFile,  Filters = { new FileFilter("ELF files", ".elf", ".ELF"), new FileFilter("All Files", ".*") }})
+                    new TableCell(this.outputFileName = new FilePicker { TabIndex = 2, FileAction = FileAction.SaveFile,  Filters = { new FileFilter("ELF files", "*.elf", "*.ELF"), new FileFilter("All Files", "*.*") }})
                 ),
                 new TableRow(
                     new TableCell(this.CreateHelpButton(4)),


### PR DESCRIPTION
This PR makes the form file know what file types it should be looking for with an optional setting for any file extension.
This also changes the file save option to automatically specify the output filename instead of users having to type .ELF manually
![](https://i.imgur.com/kM3DJXq.png)
![](https://i.imgur.com/h1FdPwH.png)
![](https://i.imgur.com/HXjsnE9.png)

Needs additional testing on macOS and Linux as I'm not sure how their file pickers behave with this change.